### PR TITLE
[README.md] fix instructions for Python HTTP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ which are used throughout the tests:
 ```
 # in one terminal
 cd certs/sp
-../..helpers/run-httpserver.sh 80
+../../helpers/run-httpserver.sh 80
 
 # in another terminal
 cd certs/sp

--- a/README.md
+++ b/README.md
@@ -157,10 +157,12 @@ which are used throughout the tests:
 
 ```
 # in one terminal
-helpers/run-httpserver.sh 80
+cd certs/sp
+../..helpers/run-httpserver.sh 80
 
 # in another terminal
-helpers/run-httpserver.sh 8080
+cd certs/sp
+../../helpers/run-httpserver.sh 8080
 ```
 
 ## Usage


### PR DESCRIPTION
Update README instructions on how to use HTTP servers to serve files.

The servers need to be started from the directories where the files we want to serve are located.