### PR TITLE
Use Docker and a script to run tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+Makefile
+README.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+FROM debian:11-slim
+
+WORKDIR /usr/local/src
+
+# Dependencies for libs we build, separated by empty lines:
+#	- essential tools
+#	- debug tools
+#	- our dependencies
+#	- libks dependencies
+#	- libjwt dependencies
+#	- libstirshaken dependencies
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		git make cmake autoconf automake ca-certificates gcc g++ gnupg2 wget \
+		lsb-release pkg-config libtool \
+		\
+		vim gdb valgrind linux-perf lsof net-tools iptables procps tcpdump \
+		sysstat libslang2 binutils openssh-client htop iputils-ping dnsutils \
+		\
+		libcryptx-perl libfaketime libuuid1 libcrypt-jwt-perl libdata-uuid-perl \
+		\
+		uuid-dev \
+		\
+		libjansson-dev \
+		\
+		libssl-dev libcurl4-openssl-dev
+
+# Install libks
+RUN git clone --branch v1.8.2 https://github.com/signalwire/libks.git \
+	&& cd libks \
+	&& cmake . -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
+	&& make -j $(nproc) \
+	&& make install
+
+# Install libjwt (for libstirshaken)
+RUN git clone https://github.com/benmcollins/libjwt.git \
+	&& cd libjwt \
+	&& git checkout tags/v1.15.2 \
+	&& autoreconf -i \
+	&& ./configure \
+	&& make all -j$(nproc) \
+	&& make install
+
+# Install libstirshaken TODO checkout a specific tag when there is one available
+RUN git clone https://github.com/signalwire/libstirshaken.git \
+	&& cd libstirshaken/ \
+	&& ./bootstrap.sh \
+	&& ./configure \
+	&& make -j $(nproc) \
+	&& make install
+
+RUN ldconfig
+
+RUN mkdir -p /home/admin/stirshaken-scenarios
+WORKDIR /home/admin/stirshaken-scenarios
+COPY . /home/admin/stirshaken-scenarios
+
+ENTRYPOINT ["/home/admin/stirshaken-scenarios/go.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+image:=stirshaken-scenarios
+version:=latest
+container:=stirshaken-scenarios
+
+#######################################################
+# Docker params
+#######################################################
+
+RUN_PARAMS:=--name ${container} \
+			--net=host
+
+SHELL_PARAMS:=${RUN_PARAMS} \
+			-v $(PWD):/opt/stirshaken-scenarios
+
+
+#######################################################
+# Docker targets
+#######################################################
+
+build:
+	@docker build -t ${image}:${version} --network host .
+
+run: pre-run
+	@docker run ${RUN_PARAMS} ${image}:${version}
+
+shell: pre-run
+	@docker run -it --entrypoint /bin/bash ${RUN_PARAMS} ${image}:${version}
+
+
+#######################################################
+# Commands for interacting with a container
+#######################################################
+
+attach:
+	@docker exec -it ${container} bash
+
+logs:
+	@docker logs  -f --since 1m ${container}
+
+stop:
+	@docker stop ${container}
+
+kill:
+	@docker kill ${container}
+
+rm:
+	@docker rm ${container}
+
+
+#######################################################
+# Internal targets
+#######################################################
+
+rm-silent:
+	@docker rm ${container} 2> /dev/null || true
+
+pre-run: rm-silent
+
+.PHONY: build run shell

--- a/README.md
+++ b/README.md
@@ -23,34 +23,19 @@ perl -pi -e 's/sipp.opensipit.sipfront.org\/cert.pem/url.of.your\/cert.pem/' hel
 perl -pi -e 's/sipp.opensipit.sipfront.org\/cert.pem/url.of.your\/cert.pem/' scenarios/*
 ```
 
-Also, due to a (for now) hardcoded path in SIPp, this repo must be cloned into your
-local path `/home/admin/stirshaken-scenarios`, otherwise it will NOT work.
-
-```
-mkdir -p /home/admin/
-cd /home/admin
-git clone https://github.com/agranig/stirshaken-scenarios.git
-```
-
 ## Prerequisites
 
-On Debian buster, install the dependencies as follows.
+This project uses Docker to build the test environment:
 
 ```
-# libks and libstirshaken1 are from the freeswitch repo
-apt-get update
-apt-get install -y gnupg2 wget lsb-release
-wget -O - https://files.freeswitch.org/repo/deb/debian-release/fsstretch-archive-keyring.asc | apt-key add -
+# Build the Docker image from the Dockerfile
+make build
 
-cat <<EOF > /etc/apt/sources.list.d/freeswitch.list
-deb http://files.freeswitch.org/repo/deb/debian-release/ buster main
-deb-src http://files.freeswitch.org/repo/deb/debian-release/ buster main
-EOF
+# Run the test suite in a Docker container
+make run
 
-apt-get update
-apt-get install -y libks libstirshaken1 libuuid1 \
-    libcrypt-jwt-perl libdata-uuid-perl libcryptx-perl \
-    libfaketime
+# Run a shell in the Docker container
+make shell
 ```
 
 ## Serving the certificates

--- a/go.sh
+++ b/go.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+# set your target here
+TARGET="kamailio.opensipit.sipfront.org"
+
+# set your caller id here
+CALLER_ID="439991001"
+
+# set your called id here
+CALLED_ID="439991002"
+
+mkdir -p "runs/$TARGET"
+
+cat <<EOF > "runs/$TARGET/caller.csv"
+SEQUENTIAL
+$CALLER_ID;$TARGET;$CALLER_ID
+EOF
+
+cat <<EOF > "runs/$TARGET/callee.csv"
+SEQUENTIAL
+$CALLED_ID;$TARGET;$CALLED_ID
+EOF
+
+for test in *.sh; do
+	echo "\n------------------ start $test"
+	./$test "$TARGET"
+	echo "------------------ $test done\n"
+	sleep 1
+done


### PR DESCRIPTION
This is a proposal to use Docker to get dependencies and run tests in a controlled environment.

- Signalwire dependencies are cloned from git repos instead of using the (sometimes outdated) package repositories
- Building and running tests is made very easy : `make build && make run`
- This also fixes needing to clone the repo in `/home/admin/stirshaken-scenarios`
