### PR TITLE
Fix create-jwt.pl 'typ' header

### DIFF
--- a/helpers/create-jwt.pl
+++ b/helpers/create-jwt.pl
@@ -25,7 +25,7 @@ my $payload = {};
 
 $header->{alg} = 'ES256';
 $header->{ppt} = 'shaken';
-$header->{type} = 'passport';
+$header->{typ} = 'passport';
 
 sub usage {
     print "$0 <args>\n".


### PR DESCRIPTION
The correct param name is 'type' not 'type'. This was caught using `stir_shaken_passport_validate_headers`from libstirshaken.